### PR TITLE
feat(mehpg): add argument details to database error functions

### DIFF
--- a/mehpg/mehpg.go
+++ b/mehpg/mehpg.go
@@ -22,10 +22,11 @@ const (
 // sets a field in details to the provided query. If the error is related to
 // constraint violation or data exceptions, a meh.ErrBadInput will be returned.
 // Otherwise, meh.ErrInternal.
-func NewQueryDBErr(err error, message string, query string) error {
+func NewQueryDBErr(err error, message string, query string, args ...any) error {
 	var finalDetailedErr error
 	details := make(meh.Details)
 	details["query"] = query
+	details["args"] = args
 	// Check if postgres error.
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
@@ -81,13 +82,14 @@ func NewQueryDBErr(err error, message string, query string) error {
 
 // NewScanRowsErr creates a new meh.ErrInternal with the given error and message
 // and saves the provided query to details.
-func NewScanRowsErr(err error, message string, query string) error {
+func NewScanRowsErr(err error, message string, query string, args ...any) error {
 	return &meh.Error{
 		Code:       meh.ErrInternal,
 		WrappedErr: err,
 		Message:    message,
 		Details: meh.Details{
 			"query": query,
+			"args":  args,
 		},
 	}
 }


### PR DESCRIPTION
The functions `NewQueryDBErr` and `NewScanRowsErr` in the `mehpg.go` file have been updated to include argument details. Now, alongside the query, any associated arguments are also saved to the 'details' field of the error. This aims to improve error contextualization and assist debugging efforts.